### PR TITLE
Use zustand store via context

### DIFF
--- a/packages/formik/package.json
+++ b/packages/formik/package.json
@@ -53,7 +53,8 @@
     "lodash-es": "^4.17.21",
     "react-fast-compare": "^2.0.1",
     "tiny-warning": "^1.0.2",
-    "tslib": "^2.0.0"
+    "tslib": "^2.0.0",
+    "zustand": "^4.4.1"
   },
   "devDependencies": {
     "@testing-library/react": "^14.0.0",

--- a/packages/formik/src/FormikContext.tsx
+++ b/packages/formik/src/FormikContext.tsx
@@ -1,22 +1,52 @@
 import * as React from 'react';
 import { FormikContextType } from './types';
 import invariant from 'tiny-warning';
+import { createStore, StoreApi } from 'zustand';
+import { useStore } from 'zustand';
 
-export const FormikContext = React.createContext<FormikContextType<any>>(
-  undefined as any
+const FormikStoreContext = React.createContext<StoreApi<FormikContextType<any>> | undefined>(
+  undefined
 );
-FormikContext.displayName = 'FormikContext';
+FormikStoreContext.displayName = 'FormikStoreContext';
 
-export const FormikProvider = FormikContext.Provider;
-export const FormikConsumer = FormikContext.Consumer;
+export function FormikProvider<Values>({
+  value,
+  children,
+}: {
+  value: FormikContextType<Values>;
+  children: React.ReactNode;
+}) {
+  const storeRef = React.useRef<StoreApi<FormikContextType<Values>>>();
+
+  if (!storeRef.current) {
+    storeRef.current = createStore<FormikContextType<Values>>(() => value);
+  }
+
+  React.useLayoutEffect(() => {
+    storeRef.current!.setState(value);
+  }, [value]);
+
+  return (
+    <FormikStoreContext.Provider value={storeRef.current}>
+      {children}
+    </FormikStoreContext.Provider>
+  );
+}
 
 export function useFormikContext<Values>() {
-  const formik = React.useContext<FormikContextType<Values>>(FormikContext);
+  const store = React.useContext(FormikStoreContext);
 
   invariant(
-    !!formik,
+    !!store,
     `Formik context is undefined, please verify you are calling useFormikContext() as child of a <Formik> component.`
   );
 
-  return formik;
+  return useStore(store!) as FormikContextType<Values>;
 }
+
+export const FormikConsumer: React.FC<{
+  children: (formik: FormikContextType<any>) => React.ReactNode;
+}> = ({ children }) => {
+  const formik = useFormikContext<any>();
+  return <>{children(formik)}</>;
+};


### PR DESCRIPTION
## Summary
- hold a zustand store instance in React context instead of global store
- update `useFormikContext` and provider to use the scoped store
- remove `formikStore` export

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*


------
https://chatgpt.com/codex/tasks/task_e_683dc44e1a988332a299d61ec0a4b28e